### PR TITLE
Player Action 

### DIFF
--- a/__tests__/core/basic_card.spec.ts
+++ b/__tests__/core/basic_card.spec.ts
@@ -51,10 +51,10 @@ describe('Basic Card', () => {
       expect(farmingVillage.supplyCount(3)).toBe(21);
       expect(farmingVillage.supplyCount(4)).toBe(28);
     });
-    test('play card', () => {
+    test('play card', async () => {
       const player = new Player();
       const farmingVillage = new FarmingVillage();
-      farmingVillage.onPlay(player);
+      await farmingVillage.onPlay(player);
       expect(player.turn.gold).toBe(1);
     });
   });
@@ -81,16 +81,16 @@ describe('Basic Card', () => {
       expect(imperialCapital.supplyCount(3)).toBe(1);
       expect(imperialCapital.supplyCount(4)).toBe(1);
     });
-    test('enroll card', () => {
+    test('enroll card', async () => {
       const player = new Player();
       const imperialCapital = new ImperialCapital();
-      imperialCapital.onEnroll(player);
+      await imperialCapital.onEnroll(player);
       expect(player.currentSuccessionPoint).toBe(8);
     });
-    test('play card', () => {
+    test('play card', async () => {
       const player = new Player();
       const imperialCapital = new ImperialCapital();
-      imperialCapital.onPlay(player);
+      await imperialCapital.onPlay(player);
       expect(player.turn.gold).toBe(5);
     });
   });

--- a/__tests__/core/player.spec.ts
+++ b/__tests__/core/player.spec.ts
@@ -1,0 +1,16 @@
+import { Player } from '../../src/core/player';
+import { FarmingVillage } from '../../src/core/basic_card';
+
+describe('Player', () => {
+  describe('Turn', () => {
+    it('should be 1 action point left after play', async () => {
+      const player = new Player();
+      const village = new FarmingVillage();
+
+      expect(player.turn.action).toBe(1);
+      await player.playCard(village);
+
+      expect(player.turn.action).toBe(1);
+    });
+  });
+});

--- a/src/core/basic_card.ts
+++ b/src/core/basic_card.ts
@@ -10,7 +10,7 @@ export class ApprenticeMaid extends Card {
   @use(Succession) public this;
 
   constructor() {
-    super('Apprentice Maid', 2);
+    super('Apprentice Maid', 2, 0);
     this._successionPoint = -2;
   }
 
@@ -26,12 +26,18 @@ export class FarmingVillage extends Card {
   @use(Land) public this;
 
   constructor() {
-    super('Farming Village', 1);
+    super('Farming Village', 1, 1);
     this._value = 1;
   }
 
   public supplyCount(playerCount: number): number {
     return 7 * playerCount;
+  }
+
+  async onPlay(player: Player): Promise<void> {
+    await super.onPlay(player);
+    player.turn.gold += this._value;
+    return Promise.resolve();
   }
 }
 
@@ -42,12 +48,18 @@ export class ImperialCapital extends Card {
   @use(Succession, Land) public this;
 
   constructor() {
-    super('Imperial Capital', 11);
+    super('Imperial Capital', 11, 1);
     this._value = 5;
     this._successionPoint = 8;
   }
 
   public supplyCount(playerCount: number): number {
     return 1;
+  }
+
+  async onPlay(player: Player): Promise<void> {
+    await super.onPlay(player);
+    player.turn.gold += this._value;
+    return Promise.resolve();
   }
 }

--- a/src/core/card_models.ts
+++ b/src/core/card_models.ts
@@ -1,13 +1,12 @@
 import { Player } from './player';
 
 export abstract class Card {
-  private readonly _name: string;
-  private readonly _cost: number;
 
-  protected constructor(name: string, cost: number) {
-    this._name = name;
-    this._cost = cost;
-  }
+  protected constructor(
+    private readonly _name: string,
+    private readonly _cost: number,
+    private readonly _actionPoint: number
+  ) {}
 
   /**
    * Return number of cards of this type in supply.
@@ -20,7 +19,9 @@ export abstract class Card {
 
   public async onGain(player: Player): Promise<void> {};
 
-  public async onPlay(player: Player): Promise<void> {};
+  public async onPlay(player: Player): Promise<void> {
+    player.turn.action += this._actionPoint;
+  };
 
   get name(): string {
     return this._name;
@@ -66,10 +67,5 @@ export class Land {
 
   get value(): number {
     return this._value;
-  }
-
-  async onPlay(player: Player): Promise<void> {
-    player.turn.gold += this._value;
-    return Promise.resolve();
   }
 }

--- a/src/core/card_struct.ts
+++ b/src/core/card_struct.ts
@@ -23,7 +23,7 @@ export class CardBuffer {
     return this.cards;
   }
 
-  public drawTo(target: CardBuffer) {
+  public drawTo(target: CardBuffer): Card {
     const card: Card = this.cards.pop();
     target.receive(card);
     return card;

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -1,12 +1,24 @@
 import { Turn } from './turn';
+import { Card } from './card_models';
+import { CardBuffer } from './card_struct';
 
 export class Player {
   private _currentSuccessionPoint: number;
   private _turn: Turn;
+  private _hand: CardBuffer;
+  private _deck: CardBuffer;
 
   constructor() {
     this._currentSuccessionPoint = 0;
     this._turn = new Turn();
+    this._hand = new CardBuffer();
+    this._deck = new CardBuffer();
+  }
+
+  public async playCard(card: Card, from: CardBuffer = null) {
+    if(from === null) from = this._hand;
+    this._turn.action -= 1;
+    await card.onPlay(this);
   }
 
   get currentSuccessionPoint(): number {

--- a/src/core/turn.ts
+++ b/src/core/turn.ts
@@ -1,8 +1,10 @@
 export class Turn {
   private _gold: number
+  private _action: number
 
   constructor() {
-    this.gold = 0;
+    this._gold = 0;
+    this._action = 1;
   }
 
   get gold(): number {
@@ -11,6 +13,14 @@ export class Turn {
 
   set gold(value: number) {
     this._gold = value;
+  }
+
+  get action(): number {
+    return this._action;
+  }
+
+  set action(value: number) {
+    this._action = value;
   }
 
 }


### PR DESCRIPTION
In Heart of Crown, unlike the Dominion, the concept of action is represented by arrows. You can only drop the card following the arrow. But it's not as easy as you think to implement it in PC games. Because you have to build a binary tree where you can decide which node you want to go into, or which node you want to append to. However, because essentially the number of arrows == add actions, this is the first step to simplify implementation.